### PR TITLE
Fix conversion to wide strings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,21 +117,20 @@ mod imp {
         )
     }
 
-    fn path_to_windows_str(x: &path::Path) -> winapi::LPCWSTR {
-        let v: Vec<winapi::WCHAR> = OsStr::new(x).encode_wide().collect();
-        v[..].as_ptr()
+    fn path_to_windows_str<T: AsRef<OsStr>>(x: T) -> Vec<winapi::WCHAR> {
+        x.as_ref().encode_wide().chain(Some(0)).collect()
     }
 
     pub fn replace_atomic(src: &path::Path, dst: &path::Path) -> io::Result<()> {
         call!(unsafe {win32kernel::MoveFileExW(
-            path_to_windows_str(src), path_to_windows_str(dst),
+            path_to_windows_str(src).as_ptr(), path_to_windows_str(dst).as_ptr(),
             winapi::MOVEFILE_WRITE_THROUGH | winapi::MOVEFILE_REPLACE_EXISTING
         )})
     }
 
     pub fn move_atomic(src: &path::Path, dst: &path::Path) -> io::Result<()> {
         call!(unsafe {win32kernel::MoveFileExW(
-            path_to_windows_str(src), path_to_windows_str(dst),
+            path_to_windows_str(src).as_ptr(), path_to_windows_str(dst).as_ptr(),
             winapi::MOVEFILE_WRITE_THROUGH
         )})
     }


### PR DESCRIPTION
The strings were missing null terminators.
Also the function `path_to_windows_str` was returning a pointer to the contents of a `Vec` which was dropped at the end of the function resulting in passing dangling pointers to `MoveFileExW`.

Do you intend to allow the temporary file to be created on a volume different than the one it will be moved to? If so, tell me, so I can add `MOVEFILE_COPY_ALLOWED` to the flags being passed since that is required for inter-volume moving.