### PR TITLE
Generalize the type of `AtomicFile::write`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 
 extern crate tempdir;
 
+use std::error::Error;
+use std::fmt;
 use std::io;
 use std::fs;
 use std::borrow::Borrow;
@@ -21,6 +23,41 @@ pub enum OverwriteBehavior {
     /// Don't overwrite files. `AtomicFile.write` will raise errors for such conditions only after
     /// you've already written your data.
     DisallowOverwrite
+}
+
+/// Represents an error raised by `AtomicFile.write`.
+#[derive(Debug)]
+pub enum AtomicWriteError<E> {
+    /// The error originated in the library itself, while it was either creating a temporary file
+    /// or moving the file into place.
+    Internal(io::Error),
+    /// The error originated in the user-supplied callback.
+    User(E)
+}
+
+impl<E: fmt::Display> fmt::Display for AtomicWriteError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            AtomicWriteError::Internal(ref e) => e.fmt(f),
+            AtomicWriteError::User(ref e) => e.fmt(f)
+        }
+    }
+}
+
+impl<E: Error> Error for AtomicWriteError<E> {
+    fn description(&self) -> &str {
+        match *self {
+            AtomicWriteError::Internal(ref e) => e.description(),
+            AtomicWriteError::User(ref e) => e.description()
+        }
+    }
+
+    fn cause(&self) -> Option<&Error> {
+        match *self {
+            AtomicWriteError::Internal(ref e) => Some(e),
+            AtomicWriteError::User(ref e) => Some(e)
+        }
+    }
 }
 
 pub struct AtomicFile {
@@ -61,21 +98,29 @@ impl AtomicFile {
 
     /// Open a temporary file, call `f` on it (which is supposed to write to it), then move the
     /// file atomically to `self.path`.
-    pub fn write<T, E, F>(&self, f: F) -> Result<T, E> where
-        E: From<io::Error>,
+    pub fn write<T, E, F>(&self, f: F) -> Result<T, AtomicWriteError<E>> where
         F: FnOnce(&mut fs::File) -> Result<T, E>
     {
-        let tmpdir = try!(TempDir::new_in(
+        macro_rules! try_internal {
+            ($expr:expr) => {
+                match $expr {
+                    Ok(r) => r,
+                    Err(e) => return Err(AtomicWriteError::Internal(e))
+                }
+            };
+        }
+
+        let tmpdir = try_internal!(TempDir::new_in(
             &self.tmpdir,
             ".atomicwrite"
         ));
 
         let tmppath = tmpdir.path().join("tmpfile.tmp");
-        let rv = try!({
-            let mut tmpfile = try!(fs::File::create(&tmppath));
-            f(&mut tmpfile)
-        });
-        try!(self.commit(&tmppath));
+        let rv = {
+            let mut tmpfile = try_internal!(fs::File::create(&tmppath));
+            try!(f(&mut tmpfile).map_err(AtomicWriteError::User))
+        };
+        try_internal!(self.commit(&tmppath));
         Ok(rv)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,10 @@ impl AtomicFile {
 
     /// Open a temporary file, call `f` on it (which is supposed to write to it), then move the
     /// file atomically to `self.path`.
-    pub fn write<E, F: FnMut(&mut fs::File) -> io::Result<E>>(&self, mut f: F) -> io::Result<E> {
+    pub fn write<T, E, F>(&self, f: F) -> Result<T, E> where
+        E: From<io::Error>,
+        F: FnOnce(&mut fs::File) -> Result<T, E>
+    {
         let tmpdir = try!(TempDir::new_in(
             &self.tmpdir,
             ".atomicwrite"


### PR DESCRIPTION
* Let the callback return any compatible error type, not just `io::Error`. For example, the serialization library I'm using (`serde_cbor`) doesn't return `io::Error` but its own custom error type.

* Take any `FnOnce` for the callback, not just `FnMut`. Since the callback is invoked only once, this bound should be more correct.