### PR TITLE
Update nix to 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/untitaker/rust-atomicwrites"
 tempdir = "0.3"
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.7.0"
+nix = "0.9.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,9 +133,17 @@ mod imp {
     use std::{io,fs,path};
     use std::os::unix::io::AsRawFd;
 
+    fn fsync<T: AsRawFd>(f: T) -> io::Result<()> {
+        match nix::unistd::fsync(f.as_raw_fd()) {
+            Ok(()) => Ok(()),
+            Err(nix::Error::Sys(errno)) => Err(errno.into()),
+            _ => unreachable!(),
+        }
+    }
+
     fn fsync_dir(x: &path::Path) -> io::Result<()> {
         let f = try!(fs::File::open(x));
-        try!(nix::unistd::fsync(f.as_raw_fd()));
+        try!(fsync(f));
         Ok(())
     }
 


### PR DESCRIPTION
Update our dep `nix` so packages dependent on `atomicwrites` could get better platform support.

As part of the upgrade, since the conversion from `nix::Error` to `io::Error` is gone (it's only applicable to the `errno`-related errors), wrap the `fsync` call manually. From [the source][nix-source], only `Error::Sys(Errno)` errors are possible for the `fsync` function, so the conversion here is safe.

[nix-source]: https://github.com/nix-rust/nix/blob/v0.9.0/src/unistd.rs#L881-L886