### PR TITLE
Update nix to 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["/.travis.yml", "/Makefile", "/appveyor.yml"]
 tempdir = "0.3"
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.13.0"
+nix = "0.14.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winbase"] }


### PR DESCRIPTION
This is needed to fix breaking changes in libc on arm and s390x.
See: https://github.com/nix-rust/nix/pull/1055