### PR TITLE
Remove minor in nix dependency to fix build on aarch64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["/.travis.yml", "/Makefile", "/appveyor.yml"]
 tempdir = "0.3"
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.14.0"
+nix = "0.14"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winbase"] }


### PR DESCRIPTION
nix version 0.14.0 does not build on Aarch64.
See https://github.com/nix-rust/nix/issues/1080 for more detail.

This was fix in `0.14.1`