### PR TITLE
Document full module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ docs:
 	cd "$(THIS_DIR)"
 	cp src/lib.rs code.bak
 	cat README.md | sed -e 's/^/\/\/! /g' > readme.bak
-	sed -i '/\/\/ DOCS/r readme.bak' src/lib.rs
+	sed -i '/\/\/ INSERT_README_VIA_MAKE/r readme.bak' src/lib.rs
 	(cargo doc --no-deps && make clean) || (make clean && false)
 
 clean:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 
 Atomic file-writes. Works on both POSIX and Windows.
 
-The basic idea is to write to temporary files, and move them when done writing.
+The basic idea is to write to temporary files (in the same file
+system), and move them when done writing.
 This avoids the problem of two programs writing to the same file. For
 `AllowOverwrite`, `rename` is used. For `DisallowOverwrite`, `link + unlink` is
 used instead to raise errors when the target path already exists.

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -82,3 +82,26 @@ fn test_weird_paths() {
     testfd.read_to_string(&mut rv).unwrap();
     assert_eq!(rv, "HELLO");
 }
+
+/// Test the error that is returned if the file already exists
+/// with `OverwriteBehavior::DisallowOverwrite`.
+#[test]
+fn disallow_overwrite_error() -> io::Result<()> {
+    let tmp = TempDir::new("test")?;
+    let file = tmp.path().join("dest");
+    let af = AtomicFile::new_with_tmpdir(&file, DisallowOverwrite, tmp.path());
+
+    // touch file
+    fs::write(&file, "")?;
+
+    match af.write(|f: &mut fs::File| f.write(b"abc")) {
+        Ok(_) => panic!("should fail!"),
+        Err(e) => {
+            let e = io::Error::from(e);
+            match e.kind() {
+                io::ErrorKind::AlreadyExists => Ok(()),
+                _ => Err(e)
+            }
+        }
+    }
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -7,7 +7,7 @@ use atomicwrites::{AtomicFile,AllowOverwrite,DisallowOverwrite};
 use tempdir::TempDir;
 
 fn get_tmp() -> path::PathBuf {
-    TempDir::new_in(".", "atomicwrites-test").unwrap().into_path()
+    TempDir::new("atomicwrites-test").unwrap().into_path()
 }
 
 #[test]


### PR DESCRIPTION
I was trying to understand the module, so I added the documentation I missed.
There’s still a `TODO`, I’m not sure whether the `tmpdir` has to exist already.

Also adds a test to verify the error returned when overwrites are disallowed. I’m not 100% sure the same error would be returned on Windows.