### PR TITLE
Replace depricated crate tempdir with tempfile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/untitaker/rust-atomicwrites"
 exclude = ["/.travis.yml", "/Makefile", "/appveyor.yml"]
 
 [dependencies]
-tempdir = "0.3"
+tempfile = "3.1"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.14.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 // INSERT_README_VIA_MAKE
-extern crate tempdir;
+extern crate tempfile;
 
 use std::error::Error as ErrorTrait;
 use std::fmt;
@@ -8,8 +8,6 @@ use std::fs;
 use std::borrow::Borrow;
 use std::path;
 use std::convert::AsRef;
-
-use tempdir::TempDir;
 
 pub use OverwriteBehavior::{AllowOverwrite, DisallowOverwrite};
 
@@ -137,7 +135,10 @@ impl AtomicFile {
     pub fn write<T, E, F>(&self, f: F) -> Result<T, Error<E>>
     where F: FnOnce(&mut fs::File) -> Result<T, E>
     {
-        let tmpdir = TempDir::new_in(&self.tmpdir, ".atomicwrite").map_err(Error::Internal)?;
+        let tmpdir = tempfile::Builder::new()
+            .prefix(".atomicwrite")
+            .tempdir_in(&self.tmpdir)
+            .map_err(Error::Internal)?;
 
         let tmppath = tmpdir.path().join("tmpfile.tmp");
         let rv = {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,13 +1,13 @@
 extern crate atomicwrites;
-extern crate tempdir;
+extern crate tempfile;
 
 use std::{env,fs,path};
 use std::io::{self,Read,Write};
 use atomicwrites::{AtomicFile,AllowOverwrite,DisallowOverwrite};
-use tempdir::TempDir;
+use tempfile::TempDir;
 
 fn get_tmp() -> path::PathBuf {
-    TempDir::new("atomicwrites-test").unwrap().into_path()
+    TempDir::new().unwrap().into_path()
 }
 
 #[test]
@@ -87,7 +87,7 @@ fn test_weird_paths() {
 /// with `OverwriteBehavior::DisallowOverwrite`.
 #[test]
 fn disallow_overwrite_error() -> io::Result<()> {
-    let tmp = TempDir::new("test")?;
+    let tmp = TempDir::new()?;
     let file = tmp.path().join("dest");
     let af = AtomicFile::new_with_tmpdir(&file, DisallowOverwrite, tmp.path());
 


### PR DESCRIPTION
closes #33 

In tempfile, the prefix is unnecessary. Should I drop it and just use [tempdir_in](https://docs.rs/tempfile/3.1.0/tempfile/struct.Builder.html#method.tempdir_in)?