### PR TITLE
Fix rust deprication warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ impl<E: fmt::Display> fmt::Display for Error<E> {
 }
 
 impl<E: ErrorTrait> ErrorTrait for Error<E> {
-    fn cause(&self) -> Option<&ErrorTrait> {
+    fn cause(&self) -> Option<&dyn ErrorTrait> {
         match *self {
             Error::Internal(ref e) => Some(e),
             Error::User(ref e) => Some(e)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,13 +55,6 @@ impl<E: fmt::Display> fmt::Display for Error<E> {
 }
 
 impl<E: ErrorTrait> ErrorTrait for Error<E> {
-    fn description(&self) -> &str {
-        match *self {
-            Error::Internal(ref e) => e.description(),
-            Error::User(ref e) => e.description()
-        }
-    }
-
     fn cause(&self) -> Option<&ErrorTrait> {
         match *self {
             Error::Internal(ref e) => Some(e),


### PR DESCRIPTION
Implicit `dyn` and `std::error::Error::describe` are deprecated.