### PR TITLE
Bump nix 0.20.0 & release 0.2.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atomicwrites"
-version = "0.2.5"
+version = "0.2.6"
 
 authors = ["Markus Unterwaditzer <markus@unterwaditzer.net>"]
 license = "MIT"
@@ -18,7 +18,7 @@ exclude = ["/.travis.yml", "/Makefile", "/appveyor.yml"]
 tempfile = "3.1"
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.14.0"
+nix = "0.20.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winbase"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atomicwrites"
-version = "0.2.6"
+version = "0.3.0"
 
 authors = ["Markus Unterwaditzer <markus@unterwaditzer.net>"]
 license = "MIT"


### PR DESCRIPTION
nix 0.20.0 has a minimum rustc requirement of 1.40, which was released
end of 2019.