### PR TITLE
Update dependency: nix: 0.21.0 -> 0.23.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["/.travis.yml", "/Makefile", "/appveyor.yml"]
 tempfile = "3.1"
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.21.0"
+nix = "0.23.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winbase"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,20 +157,7 @@ mod imp {
     use std::{fs, io, path};
 
     fn fsync<T: AsRawFd>(f: T) -> io::Result<()> {
-        match nix::unistd::fsync(f.as_raw_fd()) {
-            Ok(()) => Ok(()),
-            Err(nix::Error::Sys(errno)) => Err(errno.into()),
-            Err(nix::Error::InvalidPath) => {
-                Err(io::Error::new(io::ErrorKind::Other, "invalid path"))
-            }
-            Err(nix::Error::InvalidUtf8) => {
-                Err(io::Error::new(io::ErrorKind::Other, "invalid utf-8"))
-            }
-            Err(nix::Error::UnsupportedOperation) => Err(io::Error::new(
-                io::ErrorKind::Other,
-                "unsupported operation",
-            )),
-        }
+        Ok(nix::unistd::fsync(f.as_raw_fd())?) 
     }
 
     fn fsync_dir(x: &path::Path) -> io::Result<()> {


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2021-0119.html requires nix 0.21.2 whereas atomicwrites uses 0.21.0. Alternately nix 0.23.0 works, so proposing this upgrade