### PR TITLE
Use `std::fs::File::sync_all` instead of `nix::unistd::fsync`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,5 @@ exclude = ["/.travis.yml", "/Makefile", "/appveyor.yml"]
 [dependencies]
 tempfile = "3.1"
 
-[target.'cfg(unix)'.dependencies]
-nix = "0.21.0"
-
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winbase"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,33 +149,14 @@ impl AtomicFile {
 
 #[cfg(unix)]
 mod imp {
-    extern crate nix;
-
     use super::safe_parent;
 
     use std::os::unix::io::AsRawFd;
     use std::{fs, io, path};
 
-    fn fsync<T: AsRawFd>(f: T) -> io::Result<()> {
-        match nix::unistd::fsync(f.as_raw_fd()) {
-            Ok(()) => Ok(()),
-            Err(nix::Error::Sys(errno)) => Err(errno.into()),
-            Err(nix::Error::InvalidPath) => {
-                Err(io::Error::new(io::ErrorKind::Other, "invalid path"))
-            }
-            Err(nix::Error::InvalidUtf8) => {
-                Err(io::Error::new(io::ErrorKind::Other, "invalid utf-8"))
-            }
-            Err(nix::Error::UnsupportedOperation) => Err(io::Error::new(
-                io::ErrorKind::Other,
-                "unsupported operation",
-            )),
-        }
-    }
-
     fn fsync_dir(x: &path::Path) -> io::Result<()> {
         let f = fs::File::open(x)?;
-        fsync(f)
+        f.sync_all()
     }
 
     pub fn replace_atomic(src: &path::Path, dst: &path::Path) -> io::Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,6 @@ impl AtomicFile {
 mod imp {
     use super::safe_parent;
 
-    use std::os::unix::io::AsRawFd;
     use std::{fs, io, path};
 
     fn fsync_dir(x: &path::Path) -> io::Result<()> {


### PR DESCRIPTION
Use the Rust standard library `std::fs::File::sync_all` instead of
`nix::unistd::fsync`. Both use the same `libc::fsync` call underneath,
except on macos/ios where the standard library [uses `F_FULLFSYNC`],
which is needed to additionally ask the storage device to
[flush buffered data to permenant storage].

This also simplifies the error handling, as the code no longer has
to handle path and UTF-8 errors explicitly.

[uses `F_FULLFSYNC`]: https://github.com/rust-lang/rust/blob/3b263ceb5cb89b6d53b5a03b47ec447c3a7f7765/library/std/src/sys/unix/fs.rs#L795
[flush buffered data to permenant storage]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fcntl.2.html#//apple_ref/doc/man/2/fcntl

Fixes #13 