### PR TITLE
Bump tempfile to 3.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/untitaker/rust-atomicwrites"
 exclude = ["/.travis.yml", "/Makefile", "/appveyor.yml"]
 
 [dependencies]
-tempfile = "3.1"
+tempfile = "3.3"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winbase"] }


### PR DESCRIPTION
Tempfile 3.3 has a significantly simplified dependency tree and faster rand
crate.