### PR TITLE
Use `renameat` etc. to improve atomicity [bumps msrv]

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.44.0
+          - 1.48.0
           - stable
           - beta
           - nightly
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.44.0
+          - 1.48.0
           - stable
           - beta
           - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,8 @@ exclude = ["/.travis.yml", "/Makefile", "/appveyor.yml"]
 [dependencies]
 tempfile = "3.1"
 
+[target.'cfg(unix)'.dependencies]
+rustix = "0.34.0"
+
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winbase"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,12 +176,7 @@ mod imp {
         };
 
         // Do the `renameat`.
-        rustix::fs::renameat(
-            &src_parent,
-            src_child_path,
-            &dst_parent,
-            dst_child_path,
-            )?;
+        rustix::fs::renameat(&src_parent, src_child_path, &dst_parent, dst_child_path)?;
 
         // Fsync the parent directory (or directories, if they're different).
         src_parent.sync_all()?;
@@ -213,9 +208,9 @@ mod imp {
         // that does an atomic rename.
         #[cfg(any(target_os = "android", target_os = "linux"))]
         {
+            use rustix::fs::RenameFlags;
             use std::sync::atomic::AtomicBool;
             use std::sync::atomic::Ordering::Relaxed;
-            use rustix::fs::RenameFlags;
 
             static NO_RENAMEAT2: AtomicBool = AtomicBool::new(false);
             if !NO_RENAMEAT2.load(Relaxed) {


### PR DESCRIPTION
In `replace_atomic`, open the parent directories, use `renameat` to do
the rename, and then do `fsync` on the open parent directory file
descriptors, to be robust in case the parent directories are
concurrently renamed.

In `move_atomic`, use `renameat2` with `RENAME_NOREPLACE` when
available, and `linkat`+`unlinkat` otherwise, and do the `fsync`s on
the parent directories as in `replace_atomic`.

This adds a dependency on rustix, which requires an msrv of 1.48.

Fixes #28.