### PR TITLE
Update to rustix 0.35.6.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["/.travis.yml", "/Makefile", "/appveyor.yml"]
 tempfile = "3.1"
 
 [target.'cfg(unix)'.dependencies]
-rustix = "0.34.0"
+rustix = { version = "0.35.6", features = ["fs"] }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winbase"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,7 +247,7 @@ mod imp {
                         }
                         return Ok(());
                     }
-                    Err(rustix::io::Error::NOSYS) => {
+                    Err(rustix::io::Errno::NOSYS) => {
                         // The OS doesn't support `renameat2`; remember this so
                         // that we don't bother calling it again.
                         NO_RENAMEAT2.store(true, Relaxed);


### PR DESCRIPTION
The main change here is that rustix now puts most of its functionality behind
feature flags, which makes building rust-atomicwrites about 15% faster.