### PR TITLE
Migrate from winapi to windows-sys.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,9 @@ tempfile = "3.1"
 [target.'cfg(unix)'.dependencies]
 nix = "0.21.0"
 
-[target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["winbase"] }
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.36.0"
+features = [
+    "Win32_Foundation",
+    "Win32_Storage_FileSystem",
+]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,7 @@ mod imp {
 
 #[cfg(windows)]
 mod imp {
-    extern crate winapi;
+    extern crate windows_sys;
 
     use std::ffi::OsStr;
     use std::os::windows::ffi::OsStrExt;
@@ -217,27 +217,27 @@ mod imp {
         };
     }
 
-    fn path_to_windows_str<T: AsRef<OsStr>>(x: T) -> Vec<winapi::shared::ntdef::WCHAR> {
+    fn path_to_windows_str<T: AsRef<OsStr>>(x: T) -> Vec<u16> {
         x.as_ref().encode_wide().chain(Some(0)).collect()
     }
 
     pub fn replace_atomic(src: &path::Path, dst: &path::Path) -> io::Result<()> {
         call!(unsafe {
-            winapi::um::winbase::MoveFileExW(
+            windows_sys::Win32::Storage::FileSystem::MoveFileExW(
                 path_to_windows_str(src).as_ptr(),
                 path_to_windows_str(dst).as_ptr(),
-                winapi::um::winbase::MOVEFILE_WRITE_THROUGH
-                    | winapi::um::winbase::MOVEFILE_REPLACE_EXISTING,
+                windows_sys::Win32::Storage::FileSystem::MOVEFILE_WRITE_THROUGH
+                    | windows_sys::Win32::Storage::FileSystem::MOVEFILE_REPLACE_EXISTING,
             )
         })
     }
 
     pub fn move_atomic(src: &path::Path, dst: &path::Path) -> io::Result<()> {
         call!(unsafe {
-            winapi::um::winbase::MoveFileExW(
+            windows_sys::Win32::Storage::FileSystem::MoveFileExW(
                 path_to_windows_str(src).as_ptr(),
                 path_to_windows_str(dst).as_ptr(),
-                winapi::um::winbase::MOVEFILE_WRITE_THROUGH,
+                windows_sys::Win32::Storage::FileSystem::MOVEFILE_WRITE_THROUGH,
             )
         })
     }


### PR DESCRIPTION
This PR migrates rust-atomicwrites from winapi to windows-sys.

Windows-sys is actively maintained, by Microsoft, and has recently
started to be adopted in the ecosystem; mio, parking_lot, wasmtime,
and others have moved to windows-sys.