### PR TITLE
Update to rustix 0.36 and windows-sys 0.42.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ exclude = ["/.travis.yml", "/Makefile", "/appveyor.yml"]
 tempfile = "3.1"
 
 [target.'cfg(unix)'.dependencies]
-rustix = { version = "0.35.6", features = ["fs"] }
+rustix = { version = "0.36.0", features = ["fs"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.36.0"
+version = "0.45.0"
 features = [
     "Win32_Foundation",
     "Win32_Storage_FileSystem",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 // INSERT_README_VIA_MAKE
+#[cfg(unix)]
 extern crate rustix;
 extern crate tempfile;
 
@@ -193,7 +194,7 @@ mod imp {
         };
 
         // Do the `renameat`.
-        rustix::fs::renameat(&src_parent, src_child_path, &dst_parent, dst_child_path)?;
+        rustix::fs::renameat(&src_parent, src_child_path, dst_parent, dst_child_path)?;
 
         // Fsync the parent directory (or directories, if they're different).
         src_parent.sync_all()?;
@@ -234,7 +235,7 @@ mod imp {
                 match rustix::fs::renameat_with(
                     &src_parent,
                     src_child_path,
-                    &dst_parent,
+                    dst_parent,
                     dst_child_path,
                     RenameFlags::NOREPLACE,
                 ) {
@@ -261,7 +262,7 @@ mod imp {
         rustix::fs::linkat(
             &src_parent,
             src_child_path,
-            &dst_parent,
+            dst_parent,
             dst_child_path,
             AtFlags::empty(),
         )?;


### PR DESCRIPTION
This is mainly just to keep the dependencies in sync with other crates in the ecosystem. The main change in rustix 0.36 is to switch to the I/O safety types and traits in std, when available.