### PR TITLE
Update tempfile dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,11 @@ repository = "https://github.com/untitaker/rust-atomicwrites"
 exclude = ["/.travis.yml", "/Makefile", "/appveyor.yml"]
 
 [dependencies]
-tempfile = "3.1"
+tempfile = "3.4"
 
 [target.'cfg(unix)'.dependencies]
 rustix = { version = "0.36.0", features = ["fs"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.45.0"
-features = [
-    "Win32_Foundation",
-    "Win32_Storage_FileSystem",
-]
+features = ["Win32_Foundation", "Win32_Storage_FileSystem"]


### PR DESCRIPTION
This PR updates the tempfile dependency to `3.4`, which addresses some issues with the [`remove_dir_all`](https://github.com/Stebalien/tempfile/blob/master/NEWS#L4) sub-dependency.