### PR TITLE
Update to rustix 0.37 and windows-sys 0.48. (#57)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ exclude = ["/.travis.yml", "/Makefile", "/appveyor.yml"]
 tempfile = "3.1"
 
 [target.'cfg(unix)'.dependencies]
-rustix = { version = "0.36.0", features = ["fs"] }
+rustix = { version = "0.37.0", features = ["fs"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.45.0"
+version = "0.48.0"
 features = [
     "Win32_Foundation",
     "Win32_Storage_FileSystem",


### PR DESCRIPTION
No changes here that affect atomicwrites; this is just to keep the dependencies in sync with other crates in the ecosystem.